### PR TITLE
Fix an OCSP-related issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Experimental: It checks the OCSP response from an OCSP responder.
 
 You can set either the `--ocsp responder` or the `--ocsp fallback` option to run this checker.
 
-Known issues:
+If the status of the certificate is "good", the status will be "OK".
+If the status of the certificate is "revoked" or "unknown", the staus will be "CRITICAL".
 
-- Requests to some OCSP responders and responses from some OCSP responders will fail. Therefore, "INFO" is returned as the status instead of "WARNING" or "CRITICAL". 
+If the response has an error and the response error is "unauthorized", the status will be "CRITICAL".
+If the response error is others, the status will be "UNKNOWN".
 
 
 ## Limitations

--- a/checker/ocspresponder_test.go
+++ b/checker/ocspresponder_test.go
@@ -24,16 +24,15 @@ func TestCheckOCSPResponder(t *testing.T) {
 	checker.SetOutput(&w)
 	assert := assert.New(t)
 
-	network := "tcp4"
-	addr := "heartbeats.jp:443"
+	hostname := "heartbeats.jp"
 	tlsConfig := tls.Config{
-		ServerName:             "heartbeats.jp",
+		ServerName:             hostname,
 		InsecureSkipVerify:     true,
 		SessionTicketsDisabled: true,
 	}
 
 	dialer := net.Dialer{Timeout: time.Second * time.Duration(5)}
-	conn, _ := tls.DialWithDialer(&dialer, network, addr, &tlsConfig)
+	conn, _ := tls.DialWithDialer(&dialer, "tcp4", hostname+":443", &tlsConfig)
 	defer conn.Close()
 	connectionState := conn.ConnectionState()
 	certs := connectionState.PeerCertificates

--- a/ocsputil/ocsp.go
+++ b/ocsputil/ocsp.go
@@ -167,6 +167,14 @@ func (r ResponseStatus) Message() string {
 func GetOCSPResponse(cert *x509.Certificate, issuer *x509.Certificate) (string, []byte, error) {
 	var err error
 
+	if cert == nil {
+		return "", nil, errors.New("no server certificate")
+	}
+
+	if issuer == nil {
+		return "", nil, errors.New("no issuer certificate")
+	}
+
 	if len(cert.OCSPServer) == 0 {
 		return "", nil, errors.New("no OCSP server in certificate")
 	}
@@ -192,8 +200,10 @@ func GetOCSPResponse(cert *x509.Certificate, issuer *x509.Certificate) (string, 
 		var req *http.Request
 
 		if len(encodedOCSPRequest) < 255 {
-			u, _ := url.Parse(server)
-			u.Path = encodedOCSPRequest
+			if !strings.HasSuffix(server, "/") {
+				server = server + "/"
+			}
+			u, _ := url.Parse(server + encodedOCSPRequest)
 			req, err = http.NewRequest("GET", u.String(), nil)
 			if err != nil {
 				continue


### PR DESCRIPTION
This pull request fixes the following OCSP-related issue.

> Known issues:
> 
> Requests to some OCSP responders and responses from some OCSP responders will fail. Therefore, "INFO" is returned as the status instead of "WARNING" or "CRITICAL". 
