### PR TITLE
Fix a bug that caused the certificate chain verification to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ It verifies the digital signature, Subject, Issuer, and expiration date of the c
 The certificate chain from the root certificate to the server certificate is checked. Therefore, if the root certificate is not installed on the system, an error will occur.
 By setting the option `--root-file`, you can specify a root certificate file to validate the certificate chain.
 
+By default, system certificate directories and the environmenrt variable SSL_CERT_DIR are disabled.
+This is a workaround for the following issue:
+  https://github.com/golang/go/issues/39540
+You can enable them by setting the option `--enable-ssl-cert-dir`.
+
+
 ### OCSP Stapling Checker
 
 It checks the OCSP response obtained by OCSP stapling.
@@ -163,11 +169,12 @@ Flags:
   -P, --password-file file   password file for the private key file if the private key file is encrypted. If it is not specified, you will be prompted to enter the password.
 
 Global Flags:
-  -c, --critical days    critical threshold in days before expiration date (default 14)
-      --dn-type string   Distinguished Name Type. 'strict' (RFC 4514), 'loose' (with space), or 'openssl' (default "loose")
-      --root-file file   root certificate file (default system root certificate file)
-  -v, --verbose count    verbose mode. Multiple -v options increase the verbosity. The maximum is 3.
-  -w, --warning days     warning threshold in days before expiration date (default 28)
+  -c, --critical days         critical threshold in days before expiration date (default 14)
+      --dn-type string        Distinguished Name Type. 'strict' (RFC 4514), 'loose' (with space), or 'openssl' (default "loose")
+      --enable-ssl-cert-dir   enable system default certificate directories or environment variable SSL_CERT_DIR
+      --root-file file        root certificate file (default system root certificate file)
+  -v, --verbose count         verbose mode. Multiple -v options increase the verbosity. The maximum is 3.
+  -w, --warning days          warning threshold in days before expiration date (default 28)
 ```
 
 ### net command
@@ -191,11 +198,12 @@ Flags:
   -6, --use-ipv6                  use IPv6
 
 Global Flags:
-  -c, --critical days    critical threshold in days before expiration date (default 14)
-      --dn-type string   Distinguished Name Type. 'strict' (RFC 4514), 'loose' (with space), or 'openssl' (default "loose")
-      --root-file file   root certificate file (default system root certificate file)
-  -v, --verbose count    verbose mode. Multiple -v options increase the verbosity. The maximum is 3.
-  -w, --warning days     warning threshold in days before expiration date (default 28)
+  -c, --critical days         critical threshold in days before expiration date (default 14)
+      --dn-type string        Distinguished Name Type. 'strict' (RFC 4514), 'loose' (with space), or 'openssl' (default "loose")
+      --enable-ssl-cert-dir   enable system default certificate directories or environment variable SSL_CERT_DIR
+      --root-file file        root certificate file (default system root certificate file)
+  -v, --verbose count         verbose mode. Multiple -v options increase the verbosity. The maximum is 3.
+  -w, --warning days          warning threshold in days before expiration date (default 28)
 ```
 
 ## EXAMPLE OF EXECUTION
@@ -390,12 +398,13 @@ To get more detailed information, use the '-vv' option.
 ```
 
 ### Shell completions
+
 `check-tls-cert completion` subcommand generates the autocompletion script for shells.
 
 See `check-tls-cert completion bash/zsh/fish --help` to load them.
 
 ## LICENSE
 
-Copyright 2021 HEARTBEATS Corporation. All rights reserved.
+Copyright 2021-2022 HEARTBEATS Corporation. All rights reserved.
 
 Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.

--- a/checker/certificatechain_test.go
+++ b/checker/certificatechain_test.go
@@ -16,15 +16,19 @@ import (
 
 func TestCheckCertificateChain(t *testing.T) {
 	var (
-		state             checker.State
-		serverCert        *x509.Certificate
-		intermediateCerts []*x509.Certificate
-		rootCerts         []*x509.Certificate
+		state        checker.State
+		certs        []*x509.Certificate
+		rootCerts    []*x509.Certificate
+		rootCertPool *x509.CertPool
 	)
 	assert := assert.New(t)
 	w := strings.Builder{}
 	checker.SetOutput(&w)
 
+	// CN=server-a.test (RSA)
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -39,13 +43,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA A RSA
 	//             Expiration: 2022-02-21 17:09:50 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test (RSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -82,6 +83,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
+	// CN=server-a.test (ECDSA)
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -96,13 +101,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA A RSA
 	//             Expiration: 2022-02-21 18:34:38 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-ecdsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test (ECDSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-ecdsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -138,6 +140,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
+	// CN=server-a.test (Ed25519)
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -152,13 +158,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA A RSA
 	//             Expiration: 2022-02-21 17:09:50 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-ed25519.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test (Ed25519)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-ed25519.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -194,27 +197,28 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
-	// OK: the certificate chain is valid
-	//     - OK: ROOT CA G2 RSA
-	//         Subject   : CN=ROOT CA G2 RSA
-	//         Issuer    : CN=ROOT CA G2 RSA
-	//         Expiration: 2035-01-01 09:00:00 +0900
-	//       - OK: Intermediate CA B RSA
-	//           Subject   : CN=Intermediate CA B RSA
-	//           Issuer    : CN=ROOT CA G2 RSA
-	//           Expiration: 2031-02-22 18:50:48 +0900
-	//         - OK: server-b.test
-	//             Subject   : CN=server-b.test
-	//             Issuer    : CN=Intermediate CA B RSA
-	//             Expiration: 2022-02-21 18:50:48 +0900
-	//
-	// CN=ROOT CA G2 RSA
-	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA B RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
 	// CN=server-b.test (RSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-b-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	// CN=Intermediate CA B RSA
+	// CN=ROOT CA G2 RSA
+	//
+	// OK: the certificate chain is valid
+	//     - OK: ROOT CA G2 RSA
+	//         Subject   : CN=ROOT CA G2 RSA
+	//         Issuer    : CN=ROOT CA G2 RSA
+	//         Expiration: 2035-01-01 09:00:00 +0900
+	//       - OK: Intermediate CA B RSA
+	//           Subject   : CN=Intermediate CA B RSA
+	//           Issuer    : CN=ROOT CA G2 RSA
+	//           Expiration: 2031-02-22 18:50:48 +0900
+	//         - OK: server-b.test
+	//             Subject   : CN=server-b.test
+	//             Issuer    : CN=Intermediate CA B RSA
+	//             Expiration: 2022-02-21 18:50:48 +0900
+	//
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-b-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
+	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -251,63 +255,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA B RSA
             Expiration: `)
 
-	// OK: the certificate chain is valid
-	//     - OK: ROOT CA G2 RSA
-	//         Subject   : CN=ROOT CA G2 RSA
-	//         Issuer    : CN=ROOT CA G2 RSA
-	//         Expiration: 2035-01-01 09:00:00 +0900
-	//       - OK: Intermediate CA B RSA
-	//           Subject   : CN=Intermediate CA B RSA
-	//           Issuer    : CN=ROOT CA G2 RSA
-	//           Expiration: 2031-02-22 18:50:48 +0900
-	//         - OK: server-b.test
-	//             Subject   : CN=server-b.test
-	//             Issuer    : CN=Intermediate CA B RSA
-	//             Expiration: 2022-02-21 18:50:48 +0900
-	//
-	// CN=ROOT CA G2 RSA
-	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA B RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
 	// CN=server-b.test (ECDSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-b-ecdsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
-
-	w.Reset()
-	state.Print()
-	assert.Equal(checker.OK, state.Status)
-	assert.Contains(w.String(), "OK: the certificate chain is valid")
-
-	w.Reset()
-	state.PrintDetails(2, x509util.StrictDN)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][0].Status)
-	assert.Equal("ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].CommonName)
-	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Subject.String())
-	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Issuer.String())
-	assert.Contains(w.String(), `    - OK: ROOT CA G2 RSA
-        Subject   : CN=ROOT CA G2 RSA
-        Issuer    : CN=ROOT CA G2 RSA
-        Expiration: `)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][1].Status)
-	assert.Equal("Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][1].CommonName)
-	assert.Equal("CN=Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Subject.String())
-	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Issuer.String())
-	assert.Contains(w.String(), `      - OK: Intermediate CA B RSA
-          Subject   : CN=Intermediate CA B RSA
-          Issuer    : CN=ROOT CA G2 RSA
-          Expiration: `)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][2].Status)
-	assert.Equal("server-b.test", state.Data.([][]checker.CertificateInfo)[0][2].CommonName)
-	assert.Equal("CN=server-b.test", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Subject.String())
-	assert.Equal("CN=Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Issuer.String())
-	assert.Contains(w.String(), `        - OK: server-b.test
-            Subject   : CN=server-b.test
-            Issuer    : CN=Intermediate CA B RSA
-            Expiration: `)
-
+	// CN=Intermediate CA B RSA
+	// CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -322,13 +273,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA B RSA
 	//             Expiration: 2022-02-21 18:50:48 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-b-ecdsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA B RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
-	// CN=server-b.test (Ed25519)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-b-ed25519.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -365,27 +313,86 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA B RSA
             Expiration: `)
 
-	// OK: the certificate chain is valid
-	//     - OK: ROOT CA G2 ECDSA
-	//         Subject   : CN=ROOT CA G2 ECDSA
-	//         Issuer    : CN=ROOT CA G2 ECDSA
-	//         Expiration: 2035-01-01 09:00:00 +0900
-	//       - OK: Intermediate CA ECDSA
-	//           Subject   : CN=Intermediate CA ECDSA
-	//           Issuer    : CN=ROOT CA G2 ECDSA
-	//           Expiration: 2031-02-22 18:40:06 +0900
-	//         - OK: server-c.test
-	//             Subject   : CN=server-c.test
-	//             Issuer    : CN=Intermediate CA ECDSA
-	//             Expiration: 2022-02-21 18:40:06 +0900
+	// CN=server-b.test (Ed25519)
+	// CN=Intermediate CA B RSA
+	// CN=ROOT CA G2 RSA
 	//
-	// CN=ROOT CA G2 ECDSA
-	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-ecdsa.crt")
-	// CN=Intermediate CA ECDSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
+	// OK: the certificate chain is valid
+	//     - OK: ROOT CA G2 RSA
+	//         Subject   : CN=ROOT CA G2 RSA
+	//         Issuer    : CN=ROOT CA G2 RSA
+	//         Expiration: 2035-01-01 09:00:00 +0900
+	//       - OK: Intermediate CA B RSA
+	//           Subject   : CN=Intermediate CA B RSA
+	//           Issuer    : CN=ROOT CA G2 RSA
+	//           Expiration: 2031-02-22 18:50:48 +0900
+	//         - OK: server-b.test
+	//             Subject   : CN=server-b.test
+	//             Issuer    : CN=Intermediate CA B RSA
+	//             Expiration: 2022-02-21 18:50:48 +0900
+	//
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-b-ed25519.crt", "../test/testdata/pki/cert/valid/ca-intermediate-b-rsa.crt")
+	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
+
+	w.Reset()
+	state.Print()
+	assert.Equal(checker.OK, state.Status)
+	assert.Contains(w.String(), "OK: the certificate chain is valid")
+
+	w.Reset()
+	state.PrintDetails(2, x509util.StrictDN)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][0].Status)
+	assert.Equal("ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].CommonName)
+	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Subject.String())
+	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Issuer.String())
+	assert.Contains(w.String(), `    - OK: ROOT CA G2 RSA
+        Subject   : CN=ROOT CA G2 RSA
+        Issuer    : CN=ROOT CA G2 RSA
+        Expiration: `)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][1].Status)
+	assert.Equal("Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][1].CommonName)
+	assert.Equal("CN=Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Subject.String())
+	assert.Equal("CN=ROOT CA G2 RSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Issuer.String())
+	assert.Contains(w.String(), `      - OK: Intermediate CA B RSA
+          Subject   : CN=Intermediate CA B RSA
+          Issuer    : CN=ROOT CA G2 RSA
+          Expiration: `)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][2].Status)
+	assert.Equal("server-b.test", state.Data.([][]checker.CertificateInfo)[0][2].CommonName)
+	assert.Equal("CN=server-b.test", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Subject.String())
+	assert.Equal("CN=Intermediate CA B RSA", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Issuer.String())
+	assert.Contains(w.String(), `        - OK: server-b.test
+            Subject   : CN=server-b.test
+            Issuer    : CN=Intermediate CA B RSA
+            Expiration: `)
+
 	// CN=server-c.test (RSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-c-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	// CN=Intermediate CA ECDSA
+	// CN=ROOT CA G2 ECDSA
+	//
+	// OK: the certificate chain is valid
+	//     - OK: ROOT CA G2 ECDSA
+	//         Subject   : CN=ROOT CA G2 ECDSA
+	//         Issuer    : CN=ROOT CA G2 ECDSA
+	//         Expiration: 2035-01-01 09:00:00 +0900
+	//       - OK: Intermediate CA ECDSA
+	//           Subject   : CN=Intermediate CA ECDSA
+	//           Issuer    : CN=ROOT CA G2 ECDSA
+	//           Expiration: 2031-02-22 18:40:06 +0900
+	//         - OK: server-c.test
+	//             Subject   : CN=server-c.test
+	//             Issuer    : CN=Intermediate CA ECDSA
+	//             Expiration: 2022-02-21 18:40:06 +0900
+	//
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-c-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
+	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-ecdsa.crt")
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -422,63 +429,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA ECDSA
             Expiration: `)
 
-	// OK: the certificate chain is valid
-	//     - OK: ROOT CA G2 ECDSA
-	//         Subject   : CN=ROOT CA G2 ECDSA
-	//         Issuer    : CN=ROOT CA G2 ECDSA
-	//         Expiration: 2035-01-01 09:00:00 +0900
-	//       - OK: Intermediate CA ECDSA
-	//           Subject   : CN=Intermediate CA ECDSA
-	//           Issuer    : CN=ROOT CA G2 ECDSA
-	//           Expiration: 2031-02-22 18:40:06 +0900
-	//         - OK: server-c.test
-	//             Subject   : CN=server-c.test
-	//             Issuer    : CN=Intermediate CA ECDSA
-	//             Expiration: 2022-02-21 18:40:06 +0900
-	//
-	// CN=ROOT CA G2 ECDSA
-	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-ecdsa.crt")
-	// CN=Intermediate CA ECDSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
 	// CN=server-c.test (ECDSA)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-c-ecdsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
-
-	w.Reset()
-	state.Print()
-	assert.Equal(checker.OK, state.Status)
-	assert.Contains(w.String(), "OK: the certificate chain is valid")
-
-	w.Reset()
-	state.PrintDetails(2, x509util.StrictDN)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][0].Status)
-	assert.Equal("ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].CommonName)
-	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Subject.String())
-	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Issuer.String())
-	assert.Contains(w.String(), `    - OK: ROOT CA G2 ECDSA
-        Subject   : CN=ROOT CA G2 ECDSA
-        Issuer    : CN=ROOT CA G2 ECDSA
-        Expiration: `)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][1].Status)
-	assert.Equal("Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].CommonName)
-	assert.Equal("CN=Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Subject.String())
-	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Issuer.String())
-	assert.Contains(w.String(), `      - OK: Intermediate CA ECDSA
-          Subject   : CN=Intermediate CA ECDSA
-          Issuer    : CN=ROOT CA G2 ECDSA
-          Expiration: `)
-
-	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][2].Status)
-	assert.Equal("server-c.test", state.Data.([][]checker.CertificateInfo)[0][2].CommonName)
-	assert.Equal("CN=server-c.test", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Subject.String())
-	assert.Equal("CN=Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Issuer.String())
-	assert.Contains(w.String(), `        - OK: server-c.test
-            Subject   : CN=server-c.test
-            Issuer    : CN=Intermediate CA ECDSA
-            Expiration: `)
-
+	// CN=Intermediate CA ECDSA
+	// CN=ROOT CA G2 ECDSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 ECDSA
 	//         Subject   : CN=ROOT CA G2 ECDSA
@@ -493,13 +447,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA ECDSA
 	//             Expiration: 2022-02-21 18:40:06 +0900
 	//
-	// CN=ROOT CA G2 ECDSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-c-ecdsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-ecdsa.crt")
-	// CN=Intermediate CA ECDSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
-	// CN=server-c.test (Ed25519)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-c-ed25519.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -536,6 +487,67 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA ECDSA
             Expiration: `)
 
+	// CN=server-c.test (Ed25519)
+	// CN=Intermediate CA ECDSA
+	// CN=ROOT CA G2 ECDSA
+	//
+	// OK: the certificate chain is valid
+	//     - OK: ROOT CA G2 ECDSA
+	//         Subject   : CN=ROOT CA G2 ECDSA
+	//         Issuer    : CN=ROOT CA G2 ECDSA
+	//         Expiration: 2035-01-01 09:00:00 +0900
+	//       - OK: Intermediate CA ECDSA
+	//           Subject   : CN=Intermediate CA ECDSA
+	//           Issuer    : CN=ROOT CA G2 ECDSA
+	//           Expiration: 2031-02-22 18:40:06 +0900
+	//         - OK: server-c.test
+	//             Subject   : CN=server-c.test
+	//             Issuer    : CN=Intermediate CA ECDSA
+	//             Expiration: 2022-02-21 18:40:06 +0900
+	//
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-c-ed25519.crt", "../test/testdata/pki/cert/valid/ca-intermediate-ecdsa.crt")
+	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-ecdsa.crt")
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
+
+	w.Reset()
+	state.Print()
+	assert.Equal(checker.OK, state.Status)
+	assert.Contains(w.String(), "OK: the certificate chain is valid")
+
+	w.Reset()
+	state.PrintDetails(2, x509util.StrictDN)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][0].Status)
+	assert.Equal("ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].CommonName)
+	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Subject.String())
+	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][0].Certificate.Issuer.String())
+	assert.Contains(w.String(), `    - OK: ROOT CA G2 ECDSA
+        Subject   : CN=ROOT CA G2 ECDSA
+        Issuer    : CN=ROOT CA G2 ECDSA
+        Expiration: `)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][1].Status)
+	assert.Equal("Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].CommonName)
+	assert.Equal("CN=Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Subject.String())
+	assert.Equal("CN=ROOT CA G2 ECDSA", state.Data.([][]checker.CertificateInfo)[0][1].Certificate.Issuer.String())
+	assert.Contains(w.String(), `      - OK: Intermediate CA ECDSA
+          Subject   : CN=Intermediate CA ECDSA
+          Issuer    : CN=ROOT CA G2 ECDSA
+          Expiration: `)
+
+	assert.Equal(checker.OK, state.Data.([][]checker.CertificateInfo)[0][2].Status)
+	assert.Equal("server-c.test", state.Data.([][]checker.CertificateInfo)[0][2].CommonName)
+	assert.Equal("CN=server-c.test", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Subject.String())
+	assert.Equal("CN=Intermediate CA ECDSA", state.Data.([][]checker.CertificateInfo)[0][2].Certificate.Issuer.String())
+	assert.Contains(w.String(), `        - OK: server-c.test
+            Subject   : CN=server-c.test
+            Issuer    : CN=Intermediate CA ECDSA
+            Expiration: `)
+
+	// CN=server-a.test
+	// CN=Intermediate CA A RSA (root CA certificate not found)
+	//
 	// CRITICAL: the certificate chain is invalid / x509: certificate signed by unknown authority
 	//     - INFO: ROOT CA G2 RSA
 	//         Message   : a valid root CA certificate cannot be found, or the certificate chain is broken
@@ -549,11 +561,8 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA A RSA
 	//             Expiration: 2022-02-21 18:04:30 +0900
 	//
-	// CN=Intermediate CA A RSA (root CA certificate not found)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, []*x509.Certificate{})
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
+	state = checker.CheckCertificateChain(certs, nil)
 
 	w.Reset()
 	state.Print()
@@ -586,6 +595,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
+	// CN=server-a.test (expired)
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA
+	//
 	// CRITICAL: the certificate chain is invalid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -601,13 +614,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Expiration: 2020-01-01 09:00:00 +0900
 	//             Error     : the certificate has expired on 2020-01-01 09:00:00 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/expired/server-a-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test (expired)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/expired/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -644,6 +654,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
+	// CN=server-a.test
+	// CN=Intermediate CA A RSA (expired)
+	// CN=ROOT CA G2 RSA
+	//
 	// CRITICAL: the certificate chain is invalid / x509: certificate has expired or is not yet valid: current time 2021-06-22T10:15:58+09:00 is after 2020-01-01T00:00:00Z
 	//     - INFO: ROOT CA G2 RSA
 	//         Message   : a valid root certificate cannot be found, or the certificate chain is broken
@@ -657,13 +671,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Issuer    : CN=Intermediate CA A RSA
 	//             Expiration: 2022-02-21 18:09:37 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt", "../test/testdata/pki/cert/expired/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA (expired)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/expired/ca-intermediate-a-rsa.crt")
-	// CN=server-a.test
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -696,6 +707,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA A RSA
             Expiration: `)
 
+	// CN=server-b.test
+	// CN=Intermediate CA A RSA (not an issuer of CN=server-b.test)
+	// CN=ROOT CA G2 RSA
+	//
 	// CRITICAL: the certificate chain is invalid / x509: certificate signed by unknown authority
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -711,13 +726,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//             Expiration: 2022-02-21 18:11:42 +0900
 	//             Error     : crypto/rsa: verification error / parent certificate may not be correct issuer
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-b-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA (not an issuer of CN=server-b.test)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	// CN=server-b.test
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-b-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -754,6 +766,10 @@ func TestCheckCertificateChain(t *testing.T) {
             Issuer    : CN=Intermediate CA B RSA
             Expiration: `)
 
+	// CN=Intermediate CA A RSA (specified file not correct)
+	// CN=server-a.test (RSA) (specified file not correct)
+	// CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -764,13 +780,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//           Issuer    : CN=ROOT CA G2 RSA
 	//           Expiration: 2031-02-23 09:01:04 +0900
 	//
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt", "../test/testdata/pki/cert/valid/server-a-rsa.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=server-a.test (RSA) (specified file not correct)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	// CN=Intermediate CA A RSA (specified file not correct)
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -800,6 +813,11 @@ func TestCheckCertificateChain(t *testing.T) {
 
 	// An old-generation root CA Certificate and a cross-signing root CA Certificate
 	//
+	// CN=server-a.test
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA (cross-signing)
+	// CN=ROOT CA G1 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G1 RSA
 	//         Subject   : CN=ROOT CA G1 RSA
@@ -818,14 +836,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//               Issuer    : CN=Intermediate CA A RSA
 	//               Expiration: 2022-02-21 17:52:57 +0900
 	//
-	// CN=ROOT CA G1 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt", "../test/testdata/pki/root-ca/ca-root-g2-rsa-cross.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g1-rsa.crt")
-	// CN=Intermediate CA A RSA
-	// CN=ROOT CA G2 RSA (cross-signing)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt", "../test/testdata/pki/root-ca/ca-root-g2-rsa-cross.crt")
-	// CN=server-a.test
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()
@@ -873,6 +887,11 @@ func TestCheckCertificateChain(t *testing.T) {
 
 	// An old-generation root CA Certificate and a cross-signing root CA Certificate
 	//
+	// CN=server-a.test
+	// CN=Intermediate CA A RSA
+	// CN=ROOT CA G2 RSA (cross-signing)
+	// CN=ROOT CA G1 RSA, CN=ROOT CA G2 RSA
+	//
 	// OK: the certificate chain is valid
 	//     - OK: ROOT CA G2 RSA
 	//         Subject   : CN=ROOT CA G2 RSA
@@ -903,15 +922,10 @@ func TestCheckCertificateChain(t *testing.T) {
 	//               Issuer    : CN=Intermediate CA A RSA
 	//               Expiration: 2022-02-21 17:52:57 +0900
 	//
-	// CN=ROOT CA G1 RSA
-	// CN=ROOT CA G2 RSA
+	certs, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/server-a-rsa.crt", "../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt", "../test/testdata/pki/root-ca/ca-root-g2-rsa-cross.crt")
 	rootCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root-g1-rsa.crt", "../test/testdata/pki/root-ca/ca-root-g2-rsa.crt")
-	// CN=Intermediate CA A RSA
-	// CN=ROOT CA G2 RSA (cross-signing)
-	intermediateCerts, _ = x509util.ParseCertificateFiles("../test/testdata/pki/cert/valid/ca-intermediate-a-rsa.crt", "../test/testdata/pki/root-ca/ca-root-g2-rsa-cross.crt")
-	// CN=server-a.test
-	serverCert, _ = x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
-	state = checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts)
+	rootCertPool, _ = x509util.GetRootCertPool(rootCerts, false)
+	state = checker.CheckCertificateChain(certs, rootCertPool)
 
 	w.Reset()
 	state.Print()

--- a/checker/ocspresponder.go
+++ b/checker/ocspresponder.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CheckOCSPResponder checks the response from OCSP Responder.
-func CheckOCSPResponder(targetCert *x509.Certificate, issuer *x509.Certificate, intermediateCerts, rootCerts []*x509.Certificate) State {
+func CheckOCSPResponder(targetCert *x509.Certificate, issuer *x509.Certificate, intermediateCerts []*x509.Certificate, rootCertPool *x509.CertPool) State {
 	const name = "OCSP Responder"
 
 	var responseInfo ocsputil.OCSPResponseInfo
@@ -81,7 +81,7 @@ func CheckOCSPResponder(targetCert *x509.Certificate, issuer *x509.Certificate, 
 				}
 
 				if response.Certificate != nil {
-					err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuer, intermediateCerts, rootCerts)
+					err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuer, intermediateCerts, rootCertPool)
 					if err != nil {
 						status = CRITICAL
 						message = "ocsp: OCSP response signer's certificate error: " + err.Error()

--- a/checker/ocspresponder_test.go
+++ b/checker/ocspresponder_test.go
@@ -6,7 +6,6 @@ package checker_test
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"net"
 	"strings"
 	"testing"
@@ -62,7 +61,7 @@ func TestCheckOCSPResponder(t *testing.T) {
 	//                     00:fe:6b:e6:fc:5a:21:e3:34:74:24:cc:73:fb:d4:
 	//                     ...(omitted)
 	//                 Exponent: 65537 (0x10001)
-	state = checker.CheckOCSPResponder(targetCert, issuer, intermediateCerts, []*x509.Certificate{})
+	state = checker.CheckOCSPResponder(targetCert, issuer, intermediateCerts, nil)
 	assert.Equal(checker.OK, state.Status)
 	assert.Equal("certificate is valid", state.Message)
 

--- a/checker/ocspstapling.go
+++ b/checker/ocspstapling.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CheckOCSPStapling checks the response from OCSP Stapling.
-func CheckOCSPStapling(ocspResponse []byte, issuer *x509.Certificate, intermediateCerts, rootCerts []*x509.Certificate, allowNonReponse bool) State {
+func CheckOCSPStapling(ocspResponse []byte, issuer *x509.Certificate, intermediateCerts []*x509.Certificate, rootCertPool *x509.CertPool, allowNonReponse bool) State {
 	const name = "OCSP Stapling"
 
 	var responseInfo ocsputil.OCSPResponseInfo
@@ -64,7 +64,7 @@ func CheckOCSPStapling(ocspResponse []byte, issuer *x509.Certificate, intermedia
 				responseInfo.ResponseStatus = ocsp.Success
 
 				if response.Certificate != nil {
-					err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuer, intermediateCerts, rootCerts)
+					err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuer, intermediateCerts, rootCertPool)
 					if err != nil {
 						status = CRITICAL
 						message = "ocsp: OCSP response signer's certificate error: " + err.Error()

--- a/checker/ocspstapling_test.go
+++ b/checker/ocspstapling_test.go
@@ -33,11 +33,12 @@ func TestCheckOCSPStapling(t *testing.T) {
 	targetCert, _ := x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
 	intermediateCerts := []*x509.Certificate{issuerCert}
 	rootCerts, _ := x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root.pem")
+	rootCertPool, _ := x509util.GetRootCertPool(rootCerts, false)
 
 	priv := privateKeyInfo.Key.(*rsa.PrivateKey)
 
 	// no response, no issuer
-	state = checker.CheckOCSPStapling([]byte{}, nil, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling([]byte{}, nil, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.INFO, state.Status)
 	assert.Equal("no response sent", state.Message)
 	w.Reset()
@@ -45,7 +46,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 	assert.Equal(w.String(), "INFO: no response sent\n")
 
 	// no response
-	state = checker.CheckOCSPStapling([]byte{}, issuerCert, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling([]byte{}, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.INFO, state.Status)
 	assert.Equal("no response sent", state.Message)
 	w.Reset()
@@ -53,7 +54,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 	assert.Equal(w.String(), "INFO: no response sent\n")
 
 	// no response
-	state = checker.CheckOCSPStapling([]byte{}, issuerCert, intermediateCerts, rootCerts, false)
+	state = checker.CheckOCSPStapling([]byte{}, issuerCert, intermediateCerts, rootCertPool, false)
 	assert.Equal(checker.WARNING, state.Status)
 	assert.Equal("ocsp: no response sent", state.Message)
 	w.Reset()
@@ -89,7 +90,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 		NextUpdate:   time.Now().AddDate(0, 0, 2),
 	}
 	response, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
-	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.OK, state.Status)
 	assert.Equal("certificate is valid", state.Message)
 
@@ -142,7 +143,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 		NextUpdate:       time.Now().AddDate(0, 0, 2),
 	}
 	response, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
-	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.CRITICAL, state.Status)
 	assert.Equal("certificate has been deliberately revoked", state.Message)
 
@@ -193,7 +194,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 		NextUpdate:   time.Now().AddDate(0, 0, 2),
 	}
 	response, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
-	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.CRITICAL, state.Status)
 	assert.Equal("OCSP responder doesn't know about the certificate", state.Message)
 
@@ -244,7 +245,7 @@ func TestCheckOCSPStapling(t *testing.T) {
 		NextUpdate:   time.Now().AddDate(0, 0, 2),
 	}
 	response, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
-	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCerts, true)
+	state = checker.CheckOCSPStapling(response, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.CRITICAL, state.Status)
 	assert.Contains(state.Message, "ocsp: OCSP response signer's certificate error: x509: certificate has expired or is not yet valid:")
 

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -35,7 +35,7 @@ var (
 			rootFile, _ = homedir.Expand(rootFile)
 			passwordFile, _ = homedir.Expand(passwordFile)
 
-			code, err := file.Run(hostname, keyFile, certFile, chainFile, rootFile, caFile, passwordFile, warning, critical, dntype, verbose)
+			code, err := file.Run(hostname, keyFile, certFile, chainFile, rootFile, caFile, passwordFile, warning, critical, enableSSLCertDir, dntype, verbose)
 			if err != nil {
 				fmt.Printf("ERROR: %s\n", err.Error())
 			}

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -55,7 +55,7 @@ var (
 				os.Exit(checker.UNKNOWN.Code())
 			}
 
-			code, err := net.Run(hostname, ipAddress, port, network, tlsMinVersion, startTLS, ocspoption, timeout, rootFile, warning, critical, dntype, verbose)
+			code, err := net.Run(hostname, ipAddress, port, network, tlsMinVersion, startTLS, ocspoption, timeout, rootFile, warning, critical, enableSSLCertDir, dntype, verbose)
 			if err != nil {
 				fmt.Printf("ERROR: %s\n", err.Error())
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,12 +16,13 @@ import (
 )
 
 var (
-	hostname string
-	warning  int
-	critical int
-	rootFile string
-	dnType   string
-	verbose  int
+	hostname         string
+	warning          int
+	critical         int
+	rootFile         string
+	enableSSLCertDir bool
+	dnType           string
+	verbose          int
 
 	rootCmd = &cobra.Command{
 		Use:     "check-tls-cert",
@@ -46,6 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&warning, "warning", "w", 28, "warning threshold in `days` before expiration date")
 	rootCmd.PersistentFlags().IntVarP(&critical, "critical", "c", 14, "critical threshold in `days` before expiration date")
 	rootCmd.PersistentFlags().StringVar(&rootFile, "root-file", "", "root certificate `file` (default system root certificate file)")
+	rootCmd.PersistentFlags().BoolVar(&enableSSLCertDir, "enable-ssl-cert-dir", false, "enable system default certificate directories or environment variable SSL_CERT_DIR")
 	rootCmd.PersistentFlags().StringVar(&dnType, "dn-type", "loose", "Distinguished Name Type. 'strict' (RFC 4514), 'loose' (with space), or 'openssl'")
 	rootCmd.PersistentFlags().CountVarP(&verbose, "verbose", "v", "verbose mode. Multiple -v options increase the verbosity. The maximum is 3.")
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -6,15 +6,43 @@ package file
 
 import (
 	"crypto/x509"
+	"errors"
 
 	"github.com/heartbeatsjp/check-tls-cert/checker"
 	"github.com/heartbeatsjp/check-tls-cert/x509util"
 )
 
 // Run checks certificates.
-func Run(hostname string, keyFile string, certFile string, chainFile string, rootFile string, caFile string, passwordFile string, warning int, critical int, dnType x509util.DNType, verbose int) (int, error) {
-	var err error
-	var password []byte
+func Run(hostname string, keyFile string, certFile string, chainFile string, rootFile string, caFile string, passwordFile string, warning int, critical int, enableSSLCertDir bool, dnType x509util.DNType, verbose int) (int, error) {
+	var (
+		rootCerts    []*x509.Certificate
+		rootCertPool *x509.CertPool
+		password     []byte
+		err          error
+	)
+
+	if rootFile != "" {
+		rootCerts, err = x509util.ParseCertificateFiles(rootFile)
+		if err != nil {
+			return checker.UNKNOWN.Code(), err
+		}
+	}
+
+	rootCertPool, err = x509util.GetRootCertPool(rootCerts, enableSSLCertDir)
+	if err != nil {
+		return checker.UNKNOWN.Code(), err
+	}
+
+	certs, err := x509util.ParseCertificateFiles(certFile, chainFile)
+	if err != nil {
+		return checker.UNKNOWN.Code(), err
+	}
+
+	var serverCert *x509.Certificate
+	if len(certs) == 0 {
+		return checker.UNKNOWN.Code(), errors.New("no valid certificates")
+	}
+	serverCert = certs[0]
 
 	if len(passwordFile) > 0 {
 		password, err = x509util.ReadPasswordFile(passwordFile)
@@ -33,13 +61,6 @@ func Run(hostname string, keyFile string, certFile string, chainFile string, roo
 		return checker.UNKNOWN.Code(), err
 	}
 
-	certs, err := x509util.ParseCertificateFiles(certFile, chainFile)
-	if err != nil {
-		return checker.UNKNOWN.Code(), err
-	}
-	serverCert := certs[0]
-	intermediateCerts := certs[1:]
-
 	publicKeyInfo, err := x509util.ExtractPublicKeyFromCertificate(serverCert)
 	if err != nil {
 		return checker.UNKNOWN.Code(), err
@@ -52,21 +73,13 @@ func Run(hostname string, keyFile string, certFile string, chainFile string, roo
 		}
 	}
 
-	var rootCerts []*x509.Certificate
-	if rootFile != "" {
-		rootCerts, err = x509util.ParseCertificateFiles(rootFile)
-		if err != nil {
-			return checker.UNKNOWN.Code(), err
-		}
-	}
-
 	var stateList checker.StateList
 	stateList = append(stateList, checker.CheckCertificate(serverCert))
 	stateList = append(stateList, checker.CheckCertificateFiles(certFile, chainFile, caFile, rootFile))
 	stateList = append(stateList, checker.CheckKeyPair(publicKeyInfoInPrivateKey, publicKeyInfo))
 	stateList = append(stateList, checker.CheckHostname(hostname, serverCert))
 	stateList = append(stateList, checker.CheckValidity(serverCert, warning, critical))
-	stateList = append(stateList, checker.CheckCertificateChain(serverCert, intermediateCerts, rootCerts))
+	stateList = append(stateList, checker.CheckCertificateChain(certs, rootCertPool))
 	stateList.Print(verbose, dnType)
 	return stateList.Code(), err
 }

--- a/ocsputil/ocsp.go
+++ b/ocsputil/ocsp.go
@@ -234,7 +234,7 @@ func GetOCSPResponse(cert *x509.Certificate, issuer *x509.Certificate) (string, 
 }
 
 // VerifyAuthorizedResponder verifies the certificate of the authorized responder.
-func VerifyAuthorizedResponder(responderCert, issuer *x509.Certificate, intermediateCerts, rootCerts []*x509.Certificate) error {
+func VerifyAuthorizedResponder(responderCert, issuer *x509.Certificate, intermediateCerts []*x509.Certificate, rootCertPool *x509.CertPool) error {
 	if responderCert == nil {
 		return nil
 	}
@@ -259,17 +259,11 @@ func VerifyAuthorizedResponder(responderCert, issuer *x509.Certificate, intermed
 		return errors.New("invalid certificate")
 	}
 
-	roots, err := x509util.GetRootCertPool(rootCerts)
-	if err != nil {
-		return err
-	}
-	intermediates := x509util.GetIntermediateCertPool(intermediateCerts)
-
 	opts := x509.VerifyOptions{
-		Intermediates: intermediates,
-		Roots:         roots,
+		Intermediates: x509util.GetIntermediateCertPool(intermediateCerts),
+		Roots:         rootCertPool,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
-	_, err = responderCert.Verify(opts)
+	_, err := responderCert.Verify(opts)
 	return err
 }

--- a/ocsputil/ocsp_test.go
+++ b/ocsputil/ocsp_test.go
@@ -150,15 +150,16 @@ func TestVerifyAuthorizedResponder(t *testing.T) {
 	targetCert, _ := x509util.ParseCertificateFile("../test/testdata/pki/cert/valid/server-a-rsa.crt")
 	intermediateCerts := []*x509.Certificate{issuerCert}
 	rootCerts, _ := x509util.ParseCertificateFiles("../test/testdata/pki/root-ca/ca-root.pem")
+	rootCertPool, _ := x509util.GetRootCertPool(rootCerts, false)
 
 	priv := privateKeyInfo.Key.(*rsa.PrivateKey)
 
 	// no response, no issuer
-	err = ocsputil.VerifyAuthorizedResponder(nil, nil, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(nil, nil, intermediateCerts, rootCertPool)
 	assert.Nil(err)
 
 	// no response
-	err = ocsputil.VerifyAuthorizedResponder(nil, issuerCert, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(nil, issuerCert, intermediateCerts, rootCertPool)
 	assert.Nil(err)
 
 	// Response status: good
@@ -191,7 +192,7 @@ func TestVerifyAuthorizedResponder(t *testing.T) {
 	}
 	responseBytes, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
 	response, _ = ocsp.ParseResponse(responseBytes, issuerCert)
-	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCertPool)
 	assert.Nil(err)
 
 	// Response status: revoked
@@ -228,7 +229,7 @@ func TestVerifyAuthorizedResponder(t *testing.T) {
 	}
 	responseBytes, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
 	response, _ = ocsp.ParseResponse(responseBytes, issuerCert)
-	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCertPool)
 	assert.Nil(err)
 
 	// Response status: unknown
@@ -261,7 +262,7 @@ func TestVerifyAuthorizedResponder(t *testing.T) {
 	}
 	responseBytes, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
 	response, _ = ocsp.ParseResponse(responseBytes, issuerCert)
-	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCertPool)
 	assert.Nil(err)
 
 	// expired certificate
@@ -296,7 +297,7 @@ func TestVerifyAuthorizedResponder(t *testing.T) {
 	}
 	responseBytes, _ = ocsp.CreateResponse(issuerCert, responderCert, template, priv)
 	response, _ = ocsp.ParseResponse(responseBytes, issuerCert)
-	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCerts)
+	err = ocsputil.VerifyAuthorizedResponder(response.Certificate, issuerCert, intermediateCerts, rootCertPool)
 	assert.NotNil(err)
 	assert.Equal(x509.InvalidReason(1), err.(x509.CertificateInvalidError).Reason)
 	assert.Contains(err.(x509.CertificateInvalidError).Detail, "is after 2020-01-01T00:00:00Z")


### PR DESCRIPTION
Fix a bug that caused the certificate chain verification to fail if server certificates or intermediate certificates are placed in the system's certificate directory.
