### PR TITLE
Suppress unnecessary OCSP response data.

### DIFF
--- a/checker/ocsp_common.go
+++ b/checker/ocsp_common.go
@@ -149,7 +149,7 @@ func NewOCSPResponseData(responseInfo *OCSPResponseInfo) *OCSPResponseDetails {
 func printOCSPResponse(response *OCSPResponseDetails) {
 	printKeyValueIfExists(4, "OCSP Responder", response.OCSPResponder)
 
-	if response.OCSPResponseData != nil {
+	if response.OCSPResponseData != nil && response.OCSPResponseData.OCSPResponseStatus != "" {
 		printKey(4, "OCSP Response Data")
 		printKeyValueIfExists(8, "OCSP Response Status", response.OCSPResponseData.OCSPResponseStatus)
 		printKeyValueIfExists(8, "Cert Status", response.OCSPResponseData.CertStatus)

--- a/checker/ocspresponder_test.go
+++ b/checker/ocspresponder_test.go
@@ -45,6 +45,7 @@ func TestNewOCSPResponderChecker(t *testing.T) {
 
 	// Response status: good
 	// OK: certificate is valid
+	//     OCSP Responder: ...
 	//     OCSP Response Data:
 	//         OCSP Response Status: success (0x0)
 	//         Cert Status: good
@@ -74,6 +75,7 @@ func TestNewOCSPResponderChecker(t *testing.T) {
 
 	w.Reset()
 	c.PrintDetails()
+	assert.Contains(w.String(), `    OCSP Responder:`)
 	assert.Contains(w.String(), `    OCSP Response Data:
         OCSP Response Status: successful (0x0)
         Cert Status: good

--- a/checker/ocspstapling_test.go
+++ b/checker/ocspstapling_test.go
@@ -48,6 +48,10 @@ func TestNewOCSPStaplingChecker(t *testing.T) {
 	c.PrintStatus()
 	assert.Equal(w.String(), "INFO: no response sent\n")
 
+	w.Reset()
+	c.PrintDetails()
+	assert.Equal("", w.String())
+
 	// no response
 	c = checker.NewOCSPStaplingChecker([]byte{}, issuerCert, intermediateCerts, rootCertPool, true)
 	assert.Equal(checker.INFO, c.Status())
@@ -56,6 +60,10 @@ func TestNewOCSPStaplingChecker(t *testing.T) {
 	c.PrintStatus()
 	assert.Equal(w.String(), "INFO: no response sent\n")
 
+	w.Reset()
+	c.PrintDetails()
+	assert.Equal("", w.String())
+
 	// no response
 	c = checker.NewOCSPStaplingChecker([]byte{}, issuerCert, intermediateCerts, rootCertPool, false)
 	assert.Equal(checker.WARNING, c.Status())
@@ -63,6 +71,10 @@ func TestNewOCSPStaplingChecker(t *testing.T) {
 	w.Reset()
 	c.PrintStatus()
 	assert.Equal(w.String(), "WARNING: ocsp: no response sent\n")
+
+	w.Reset()
+	c.PrintDetails()
+	assert.Equal("", w.String())
 
 	// Response status: good
 	// OK: certificate is valid


### PR DESCRIPTION
This pull request suppresses unnecessary OCSP response data if the OCSP response data is empty.